### PR TITLE
set expressionSeries widget default to false

### DIFF
--- a/src/plugin/config.yml
+++ b/src/plugin/config.yml
@@ -95,7 +95,7 @@ install:
             viewers:
                 -
                     title: Data View
-                    default: true
+                    default: false
                     widget:
                         name: kb_datawidgets_expression_expressionSeries                        
                     panel: false


### PR DESCRIPTION
Since the type-to-viewer api/ui-service now prohibits duplicate 
default viewers, one of them has to go, so this one should.
